### PR TITLE
Encoding and decoding of protobuf well-known value types

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -105,10 +105,6 @@ func (enc *Encoder) safeEncode(key Key, rv reflect.Value) (err error) {
 	return nil
 }
 
-type wkt interface {
-	XXX_WellKnownType() string
-}
-
 func (enc *Encoder) encode(key Key, rv reflect.Value) {
 	// Special case. Time needs to be in ISO8601 format.
 	// Special case. If we can marshal the type to text, then we used that.

--- a/protobuf.go
+++ b/protobuf.go
@@ -1,0 +1,5 @@
+package toml
+
+type wkt interface {
+	XXX_WellKnownType() string
+}


### PR DESCRIPTION
This patch adds the ability serialize/deserialize protbuf value types without bringing along the outer object.
For example,
```
	message System {
		google.protobuf.Int32Value port = 2;
	}
```

now gets serialized as
```
port = 32
```

instead of
```
[port]
value = 32
```
