### PR TITLE
Fix the bug where proto wkt values end up in the wrong place

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -413,6 +413,14 @@ func tomlTypeOfGo(rv reflect.Value) tomlType {
 		}
 		return tomlArray
 	case reflect.Ptr, reflect.Interface:
+		if v, ok := rv.Interface().(wkt); ok {
+			switch v.XXX_WellKnownType() {
+			case "DoubleValue", "FloatValue", "Int64Value", "UInt64Value",
+				"Int32Value", "UInt32Value", "BoolValue", "StringValue", "BytesValue":
+				s := reflect.ValueOf(v).Elem()
+				return tomlTypeOfGo(s.Field(0))
+			}
+		}
 		return tomlTypeOfGo(rv.Elem())
 	case reflect.String:
 		return tomlString

--- a/encode_test.go
+++ b/encode_test.go
@@ -7,16 +7,23 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/gogo/protobuf/types"
 )
 
 func TestEncodeRoundTrip(t *testing.T) {
+	type Foo struct {
+		Value string
+	}
 	type Config struct {
 		Age        int
 		Cats       []string
 		Pi         float64
 		Perfection []int
 		DOB        time.Time
+		Foo        Foo
 		Ipaddress  net.IP
+		Wkt        *types.StringValue
 	}
 
 	var inputs = Config{
@@ -25,7 +32,9 @@ func TestEncodeRoundTrip(t *testing.T) {
 		3.145,
 		[]int{11, 2, 3, 4},
 		time.Now(),
+		Foo{"Foo"},
 		net.ParseIP("192.168.59.254"),
+		&types.StringValue{"Hello"},
 	}
 
 	var firstBuffer bytes.Buffer


### PR DESCRIPTION
WKT values were ending up treated more like structs, so they would
end up appearing after a table definition. This meant that their parent key
would be the last written struct instead of their parent