### PR TITLE
Update wrapper type handling for removal of XXX methods

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -168,6 +168,15 @@ func (md *MetaData) unify(data interface{}, rv reflect.Value) error {
 			return v.UnmarshalTOML(data)
 		}
 
+		if v, ok := rv.Addr().Interface().(protoreflector); ok {
+			switch v.ProtoReflect().Descriptor().Name() {
+			case "DoubleValue", "FloatValue", "Int64Value", "UInt64Value",
+				"Int32Value", "UInt32Value", "BoolValue", "StringValue", "BytesValue":
+				s := reflect.ValueOf(v).Elem()
+				return md.unify(data, s.FieldByName("Value"))
+			}
+		}
+
 		if v, ok := rv.Addr().Interface().(wkt); ok {
 			switch v.XXX_WellKnownType() {
 			case "DoubleValue", "FloatValue", "Int64Value", "UInt64Value",

--- a/protobuf.go
+++ b/protobuf.go
@@ -1,5 +1,11 @@
 package toml
 
+import "google.golang.org/protobuf/reflect/protoreflect"
+
 type wkt interface {
 	XXX_WellKnownType() string
+}
+
+type protoreflector interface {
+	ProtoReflect() protoreflect.Message
 }


### PR DESCRIPTION
Generated go code no longer contains the "XXX" methods which were
supposed to be private and upon which we relied to detect wrappers. We
now instead use protoreflect to detect these types and represent them as
their primitive values in toml.